### PR TITLE
Fix imports for backward compactibility

### DIFF
--- a/mongoengine/__init__.py
+++ b/mongoengine/__init__.py
@@ -21,17 +21,16 @@ Asynchronous functionality is backed by PyMongo's native async support
 
 from mongoengine import document, errors, fields, signals
 
+
 # ---- private imports (for __all__ only) ----
-from mongoengine.synchronous import connection as _sync_connection
-from mongoengine.asynchronous import connection as _async_connection
-from mongoengine.synchronous import queryset as _sync_queryset
-from mongoengine.asynchronous import queryset as _async_queryset
+import mongoengine.base.queryset as _queryset_base
+import mongoengine.synchronous as _sync_modules
+import mongoengine.asynchronous as _async_modules
 
 # ---- public re-exports ----
-from mongoengine.synchronous.connection import *  # noqa: F401,F403
-from mongoengine.asynchronous.connection import *  # noqa: F401,F403
-from mongoengine.synchronous.queryset import *  # noqa: F401,F403
-from mongoengine.asynchronous.queryset import *  # noqa: F401,F403
+from mongoengine.base.queryset import *  # noqa: F401,F403
+from mongoengine.synchronous import *  # noqa: F401,F403
+from mongoengine.asynchronous import *  # noqa: F401,F403
 
 from mongoengine.document import *  # noqa: F401,F403
 from mongoengine.errors import *  # noqa: F401,F403
@@ -42,19 +41,17 @@ from mongoengine.signals import *  # noqa: F401,F403
 __all__ = (
     list(document.__all__)
     + list(fields.__all__)
-    + list(_sync_connection.__all__)
-    + list(_async_connection.__all__)
-    + list(_sync_queryset.__all__)
-    + list(_async_queryset.__all__)
+    + list(_queryset_base.__all__)
+    + list(_sync_modules.__all__)
+    + list(_async_modules.__all__)
     + list(signals.__all__)
     + list(errors.__all__)
 )
 
 # ---- hide internals ----
-del _sync_connection
-del _async_connection
-del _sync_queryset
-del _async_queryset
+del _queryset_base
+del _sync_modules
+del _async_modules
 
 VERSION = (0, 30, 0)
 

--- a/mongoengine/asynchronous/__init__.py
+++ b/mongoengine/asynchronous/__init__.py
@@ -1,6 +1,13 @@
-from .connection import *
-from .queryset import *
+import mongoengine.asynchronous.connection as _connection
 
-__all__ = [
-    list(connection.__all__) + list(queryset.__all__),
-]
+from .connection import *  # noqa: F401,F403
+from .queryset import (  # noqa: F401,F403
+    AsyncQuerySet,
+    AsyncQuerySetNoCache,
+    queryset as _queryset,
+)
+
+__all__ = list(_connection.__all__) + list(_queryset.__all__)
+
+del _queryset
+del _connection

--- a/mongoengine/asynchronous/connection.py
+++ b/mongoengine/asynchronous/connection.py
@@ -6,7 +6,14 @@ from pymongo.driver_info import DriverInfo
 from pymongo.errors import ConnectionFailure
 
 import mongoengine
-from mongoengine.common import _check_db_name, convert_read_preference
+from mongoengine.common import (
+    _check_db_name,
+    convert_read_preference,
+    DEFAULT_CONNECTION_NAME,
+    DEFAULT_DATABASE_NAME,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+)
 
 __all__ = [
     "async_connect",
@@ -15,14 +22,11 @@ __all__ = [
     "async_get_connection",
     "async_get_db",
     "async_register_connection",
+    "DEFAULT_CONNECTION_NAME",
+    "DEFAULT_DATABASE_NAME",
 ]
 
 from mongoengine.registry import _CollectionRegistry
-
-DEFAULT_CONNECTION_NAME = "default"
-DEFAULT_DATABASE_NAME = "test"
-DEFAULT_HOST = "localhost"
-DEFAULT_PORT = 27017
 
 READ_PREFERENCE = ReadPreference.PRIMARY
 

--- a/mongoengine/base/queryset/__init__.py
+++ b/mongoengine/base/queryset/__init__.py
@@ -1,14 +1,18 @@
 from .constants import *
-from .visitor import *
-from .transform import *
 from .field_list import *
 from .manager import *
+from .transform import *
+from .visitor import *
 
 # Expose just the public subset of all imported objects and constants.
 __all__ = (
-    list(constants.__all__)
-    + list(visitor.__all__)
-    + list(transform.__all__)
-    + list(field_list.__all__)
-    + list(manager.__all__)
+    "Q",
+    "queryset_manager",
+    "QuerySetManager",
+    "QueryFieldList",
+    "DO_NOTHING",
+    "NULLIFY",
+    "CASCADE",
+    "DENY",
+    "PULL",
 )

--- a/mongoengine/common.py
+++ b/mongoengine/common.py
@@ -7,6 +7,11 @@ from pymongo.read_preferences import (
     Nearest,
 )
 
+DEFAULT_CONNECTION_NAME = "default"
+DEFAULT_DATABASE_NAME = "test"
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 27017
+
 _class_registry_cache = {}
 _field_list_cache = []
 

--- a/mongoengine/synchronous/__init__.py
+++ b/mongoengine/synchronous/__init__.py
@@ -1,6 +1,13 @@
-from .connection import *
-from .queryset import *
+import mongoengine.synchronous.connection as _connection
 
-__all__ = [
-    list(connection.__all__) + list(queryset.__all__),
-]
+from .connection import *  # noqa: F401,F403
+from .queryset import (  # noqa: F401,F403
+    QuerySet,
+    QuerySetNoCache,
+    queryset as _queryset,
+)
+
+__all__ = list(_connection.__all__) + list(_queryset.__all__)
+
+del _queryset
+del _connection

--- a/mongoengine/synchronous/connection.py
+++ b/mongoengine/synchronous/connection.py
@@ -6,7 +6,14 @@ from pymongo.driver_info import DriverInfo
 from pymongo.errors import ConnectionFailure
 
 import mongoengine
-from mongoengine.common import _check_db_name, convert_read_preference
+from mongoengine.common import (
+    _check_db_name,
+    convert_read_preference,
+    DEFAULT_CONNECTION_NAME,
+    DEFAULT_DATABASE_NAME,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+)
 
 __all__ = [
     "connect",
@@ -15,14 +22,12 @@ __all__ = [
     "get_connection",
     "get_db",
     "register_connection",
+    "DEFAULT_CONNECTION_NAME",
+    "DEFAULT_DATABASE_NAME",
 ]
 
 from mongoengine.registry import _CollectionRegistry
 
-DEFAULT_CONNECTION_NAME = "default"
-DEFAULT_DATABASE_NAME = "test"
-DEFAULT_HOST = "localhost"
-DEFAULT_PORT = 27017
 
 READ_PREFERENCE = ReadPreference.PRIMARY
 

--- a/tests/asynchronous/queryset/test_queryset.py
+++ b/tests/asynchronous/queryset/test_queryset.py
@@ -11,6 +11,7 @@ from pymongo.read_preferences import ReadPreference
 from pymongo.results import UpdateResult
 
 from mongoengine import *
+from mongoengine.asynchronous.queryset import AsyncBaseQuerySet
 from mongoengine.base import LazyReference
 from mongoengine.base.queryset import (
     CASCADE,


### PR DESCRIPTION
## Fix: Broken Imports wrt to `origin/mongoengine`

### Restored Queryset Module Imports
Brought back the following components to fix broken imports:
* `Q`
* `queryset_manager`
* `QuerySetManager`
* `QueryFieldList`
* `DO_NOTHING`
* `NULLIFY`
* `CASCADE`
* `DENY`
* `PULL`

### Backward-Compatibility Fixes
Re-added global connection defaults to prevent breaking downstream dependencies:
* `DEFAULT_CONNECTION_NAME`
* `DEFAULT_DATABASE_NAME`

###  Removed Unwanted Exports & Classes
Cleaned up the public API by removing internal dependencies:
* **From `base.transform`:** Removed `query`, `update`, and `STRING_OPERATORS`
* **Querysets:** Removed `AsyncBaseQuerySet` and `BaseQuerySet`